### PR TITLE
Fix typo in docs-api SinkMapper example-1

### DIFF
--- a/docs/api/latest.md
+++ b/docs/api/latest.md
@@ -50,7 +50,7 @@
 <span id="examples" class="md-typeset" style="display: block; font-weight: bold;">Examples</span>
 <span id="example-1" class="md-typeset" style="display: block; color: rgba(0, 0, 0, 0.54); font-size: 12.8px; font-weight: bold;">EXAMPLE 1</span>
 ```
-@sink(type='inMemory', topic='stock', @map(type='avro',schema.def = """{"type":"record","name":"stock","namespace":"stock.example","fields":[{"name":"symbol","type":"string"},{"name":"price":"type":"float"},{"name":"volume","type":"long"}]}"""))
+@sink(type='inMemory', topic='stock', @map(type='avro',schema.def = """{"type":"record","name":"stock","namespace":"stock.example","fields":[{"name":"symbol","type":"string"},{"name":"price","type":"float"},{"name":"volume","type":"long"}]}"""))
 define stream StockStream (symbol string, price float, volume long);
 ```
 <p style="word-wrap: break-word">The above configuration performs a default Avro mapping that generates an Avro message as an output ByteBuffer.</p>


### PR DESCRIPTION
## Purpose
>Fixing a typo in api docs latest SinkMapper example1

