### PR TITLE
remove feign from import package

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -189,8 +189,6 @@
                         </Export-Package>
                         <Import-Package>
                             com.fasterxml.jackson.databind.*;version="${com.fasterxml.jackson.databind.range}",
-                            feign.codec;version="${feign.version.range}",
-                            feign.gson;version="${feign.version.range}",
                             javax.annotation,
                             javax.xml,
                             org.apache.log4j.*;version="${org.apache.log4j.version.range}",


### PR DESCRIPTION
## Purpose
> $Subject

## Goals
> Fixing java.lang.LinkageError: loader constraint violation: loader (instance of org/eclipse/osgi/internal/loader/EquinoxClassLoader) previously initiated loading for a different type with name "feign/Response" which occurs when testing Kafka-Avro samples in SI.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes