### PR TITLE
Bump json-path version and Remove the private packaged json-path related dependencies

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -195,9 +195,6 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            com.jayway.jsonpath.*,
-                            net.minidev.*,
-                            org.objectweb.asm.*,
                             avro.shaded.com.google.common.*,
                             com.thoughtworks.paranamer.*,
                             org.apache.commons.compress.utils.*,
@@ -225,6 +222,8 @@
                             io.siddhi.annotation.*;version="${io.siddhi.version.range}",
                             io.siddhi.core.*;version="${io.siddhi.version.range}",
                             io.siddhi.query.api.definition.*;version="${io.siddhi.version.range}",
+                            com.jayway.jsonpath.*;version="${com.jayway.jsonpath.version.range}",
+                            net.minidev.*;version="${net.minidev.json-smart.version.range}",
                             *;resolution:=optional,
                     </Import-Package>
                         <Include-Resource>

--- a/pom.xml
+++ b/pom.xml
@@ -323,10 +323,10 @@
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <jackson.version>2.13.3</jackson.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
-        <jsonpath.version>2.2.0</jsonpath.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
         <gson.version>2.8.0</gson.version>
         <tapestry.json.orbit.version>5.4.1.wso2v1</tapestry.json.orbit.version>
-        <net.minidev.version>2.4.7</net.minidev.version>
+        <net.minidev.version>2.5.0</net.minidev.version>
         <jacoco.version>0.7.9</jacoco.version>
         <avro.version>1.8.2</avro.version>
         <feign.version>9.5.0</feign.version>
@@ -346,6 +346,8 @@
         <org.slf4j.version.range>[1.7,2)</org.slf4j.version.range>
         <org.osgi.framework.version.range>[1.8,2)</org.osgi.framework.version.range>
         <org.apache.log4j.version.range>[1.2,2)</org.apache.log4j.version.range>
+        <com.jayway.jsonpath.version.range>[2.2.0,3.0.0)</com.jayway.jsonpath.version.range>
+        <net.minidev.json-smart.version.range>[2.5.0,3.0.0)</net.minidev.json-smart.version.range>
 
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
         <mavan.checkstyle.suppression.file>checkstyle-suppressions.xml</mavan.checkstyle.suppression.file>


### PR DESCRIPTION
## Purpose

This PR adds the following changes,

- Bump json-path version to 2.9.0
- Bump json-smart version to 2.5.0
- Remove the private packaged json-path and json-smart dependencies